### PR TITLE
Fix quick-start ubuntu user

### DIFF
--- a/quick-start.md
+++ b/quick-start.md
@@ -239,7 +239,7 @@ phenix exp start my_first_experiment
 
 		![](img/vnc.png)
 
-	- Login as the `ubuntu` user (with password `ubuntu`) for either of the VMs and trying pinging the other IP address:
+	- Login as the `root` user for either of the VMs and trying pinging the other IP address:
 
 		![](img/ping.png)
 


### PR DESCRIPTION
While following the quick-start, I realized that the username for the test VMs was "root", not "ubuntu". This can be seen in the screenshot.