### PR TITLE
Docs: Initial provider documentation

### DIFF
--- a/08-sceptre-user-app.md
+++ b/08-sceptre-user-app.md
@@ -93,7 +93,7 @@ The SCEPTRE app is configured by specifying the desired configurations in a scen
 ### Provider
 
 - `type: provider`
-- `simulator`: Specifies the type of simulator used. Current options are: `PowerWorld`, `PowerWorldDynamics`, `PowerWorldHelics`, `PyPower`, `Simulink`, `RTDS`, `OpenDSS`, `Alicanto`
+- `simulator`: Specifies the type of simulator used. Current options are: `PowerWorld`, `PowerWorldDynamics`, `PowerWorldHelics`, `PyPower`, `Simulink`, `RTDS`, `OpenDSS`, `Alicanto`, `GenericPython`
 - `publish_endpoint`: Endpoint address for the UDP multicast traffic from the provider. Default value if unset is `udp://*;239.0.0.1:40000`.
 - `case`: If using a PowerWorld provider, this is the associated PowerWorld case file for the physical process simulation. If using a PyPower provider, this is the associated PyPower case file for the physical process simulation.
 - `oneline`: If using a PowerWorld provider, this is the associated PowerWorld oneline diagram for the physical process simulation.
@@ -102,13 +102,15 @@ The SCEPTRE app is configured by specifying the desired configurations in a scen
 - `publish_points`: If using a Simulink provider, this is a list of tags form the physical process simulation for the provider to publish to the field devices.
 - `gt`: If using a Simulink provider, this is the compiled executable for the ground truth data from the physical process simulation. Note that this is not required for the provider to function, this is a optional feature.
 - `gt_template`: If using a Simulink provider, this is the web template for displaying the ground truth data from the physical process simulation. Note that this is not required for the provider to function, this is a optional feature.
+- `simulation_file`: If using a Python provider, this is the python script containing the physical process simulation. 
 - `hil_tags`: If using [HIL](glossary.md#acronyms), a list of tags from the provider that will be sent to the HIL devices.
+
 
 ### Field Device
 
 - `type`: Field device type. Types: `fd-server`, `fd-client`, or `fep`.
 - `provider`: Hostname of the provider that the field device is getting data from.
-- `infrastructure`: Type of infrastructure that the provider is modeling. Types include: `power-transmission`, `power-distribution`, `batch-process`, `hvac`, `fuel`, `rtds`, `waterway`, and `battery`.
+- `infrastructure`: Type of infrastructure that the provider is modeling. Types include: `power-transmission`, `power-distribution`, `batch-process`, `hvac`, `fuel`, `rtds`, `waterway`, `battery` and `generic`.
 - `logic`: If specified, this contains any logic that the field device will be applying to input from the provider and writing back to the provider. The logic is implemented using [cparse](https://github.com/cparse/cparse). Refer to the cparse README for available operators, and the example below for example logic (as well as the open-source topology examples at [sceptre-phenix-topologies](https://github.com/sandialabs/sceptre-phenix-topologies)).
 - `cycle_time`: If specified, this determines at what rate the field device goes through an input/logic/output cycle.
 - `dnp3`, `dnp3-serial`, `modbus`, `modbus-serial`, `bacnet`, or `iec60870-5-104` If specified, one of these keys define what SCADA protocols the device will speak using the selected tags.

--- a/08-sceptre-user-app.md
+++ b/08-sceptre-user-app.md
@@ -102,7 +102,7 @@ The SCEPTRE app is configured by specifying the desired configurations in a scen
 - `publish_points`: If using a Simulink provider, this is a list of tags form the physical process simulation for the provider to publish to the field devices.
 - `gt`: If using a Simulink provider, this is the compiled executable for the ground truth data from the physical process simulation. Note that this is not required for the provider to function, this is a optional feature.
 - `gt_template`: If using a Simulink provider, this is the web template for displaying the ground truth data from the physical process simulation. Note that this is not required for the provider to function, this is a optional feature.
-- `simulation_file`: If using a Python provider, this is the python script containing the physical process simulation. 
+- `simulation_file`: If using a GenericPython provider, this is the python script containing the physical process simulation. 
 - `hil_tags`: If using [HIL](glossary.md#acronyms), a list of tags from the provider that will be sent to the HIL devices.
 
 

--- a/13-providers.md
+++ b/13-providers.md
@@ -1,0 +1,110 @@
+# End-Process Simulations
+
+End-process simulations are a critical part of SCEPTRE. They simulate the physical part of the system being emulated. End-process simulations consist of two pieces: 1) a [solver](glossary.md#terminology) which is the physical process simulation itself and 2) a [provider](glossary.md#terminology) which is a service responsible for processing data exchange (both input and output) between the solver and the SCEPTRE field devices. Various tools for end-process simulation have been integrated into SCEPTRE and include: 
++ PowerWorld
++ RTDS
++ OpenDSS
++ PyPower
++ Matlab Simulink 
++ GenericPython
+
+Implementation of new end-process simulations into SCEPTRE involve connecting many pieces of information to ensure end-to-end data flow. Below, outlines how to create a generic python simulation that integrates with SCEPTRE. Details on the other simulations will be released soon. 
+
+## Generic Python Provider
+The `GenericPython` provider was developed for quick and easy development of discrete event simulations that do not require extensive system specific modeling tools like power systems. 
+
+To create a new generic python solver, a simple python script needs to be developed representing the desired physics. The script must define a class `Simulation` which inherits from the SCEPTRE `GenericPython` solver base class `BaseSimulation` and implements the `__int__` method which defines data input/output that make up the simulation `state` and the `update_state` method which defines the dynamics of the simulation per time step. 
+
+The names of the variables defined in the simulation `state` must be of the format `device.field` and the chosen naming convention must align with the downstream SCEPTRE infrastructure used in the scenario file configuration. Furthermore, variables in the state must be categorized as either inputs (independent variables of the simulation that can be changed to have effect of the simulation state) or outputs (dependent variables of the simulation) and their data type must be defined as either analog (integer and float) or binary (boolean). 
+
+Below is an example of a generic python solver for a simple heater/cooler system controlled by a thermostat. Note the physics in this example are drastically simplified for example purposes. The simulation has two inputs: 
++ The temperature the thermostat is set to `temperature_setpoint.value`
++ The state of the thermostat being on/off `on.status`. 
+
+The simulation has three outputs:
++ The current temperature of the room `temperature.value`
++ The difference in temperature between the room and thermostat value `temperature_diff.value`
++ The indicator of if the room is at the setpoint of the thermostat `at_temp.status`
+
+On each timestep of the simulation, the outputs of the simulation update:
++ If the thermostat is on and the difference between the room temperature and thermostat setpoint is negative (room temperature is below thermostat setting) then the heater heats up the room by 1 degree. 
++ If the thermostat is on and the difference between the room temperature and thermostat setpoint is positive (the temperature is above thermostat setting) then the cooler cools down the room by 1 degree. 
++ Update the difference between the room temperature and the thermostat setpoint.
++ Calculate if the room temperature has reached the thermostat setpoint. 
+
+```
+from pybennu.providers.power.solvers.generic_python.base_simulation import BaseSimulation
+
+class Simulation(BaseSimulation):
+    """Simulation class for demonstration purposes."""
+
+    def __init__(self):
+        dt = 1
+        super().__init__(dt)
+
+        """In the simulator, inputs are inputs to the simulation (outputs from a fd) and vice versa"""
+        self.state = {
+            'input': {
+                'analog': {
+                    'temperature_setpoint.value': 100.0
+                },
+                'binary': {
+                    'on.status': True
+                }
+            },
+            'output': {
+                'analog': {
+                    'temperature.value': 25.0,
+                    'temperature_diff.value': 75.0
+                },
+                'binary': {
+                    'at_temp.status': False
+                }
+            }
+        }
+        self.check_state()
+
+    def update_state(self):
+        # Simulate changes in outputs based on inputs
+        #if on, change heat to setpoint, otherwise, do nothing
+        if self.state['input']['binary']['on.status']:
+            if self.state['output']['analog']['temperature_diff.value'] > 0:
+                self.state['output']['analog']['temperature.value'] -= 1
+            elif self.state['output']['analog']['temperature_diff.value'] < 0:
+                self.state['output']['analog']['temperature.value'] += 1
+        self.state['output']['analog']['temperature_diff.value'] = self.state['output']['analog']['temperature.value'] - self.state['input']['analog']['temperature_setpoint.value']
+        self.state['output']['binary']['at_temp.status'] = (self.state['output']['analog']['temperature_diff.value'] == 0)
+``` 
+
+Once the solver is implemented, it is time to integrate with the SCEPTRE scenario config file and the [SCEPTRE app](08-sceptre-user-app.md) specifically. The provider device in the scenario configuration file for a python simulation must include the metadata fields `publish_endpoint`, `simulator: GenericPython`, `simulation_file` which points to the location of the above mentioned simulation, and `type:provider`. Below is an example provider configuration. 
+
+```yaml
+- hostname: provider
+  metadata:
+    publish_endpoint: udp://*;239.0.0.1:40000
+    simulator: GenericPython
+    simulation_file: <path_to>/simulation.py
+    type: provider
+```
+
+Finally, the SCEPTRE field device configuration must be added to read/write data from the simulation. The most important part of this step is to ensure that the naming convention defined in the associated `infrastructure` maps to the variable naming convention used in the implemented solver. 
+
+Below is an example for the heater/cooler solver. This field device configuration uses the `generic` infrastucture. This infrastructure expects any analog variables in the solver to be of the form `<variable name>.value` and any binary variables to be of the form `<variable name>.status`. This configuration also maps inputs/outputs of the solver to registers in the field device. Note that "inputs" to the solver are variables that the field device can both read and write to, while "outputs" of the solver can only be read by the field device.
+```yaml
+- hostname: rtu-1
+  metadata:
+    modbus:
+    - name: temperature
+      type: analog-read
+    - name: temperature_diff
+      type: analog-read
+    - name: at_temp
+      type: binary-read
+    - name: temperature-setpoint
+      type: analog-read-write
+    - name: on
+      type: binary-read-write
+    infrastructure: generic
+    provider: provider
+    type: fd-server
+```


### PR DESCRIPTION
# Initial Provider documentation

## Description
Documentation to describe providers and connections to field-devices. Specifically includes example using `GenericPython` provider.   

## Related Issue
NA

## Type of Change
Please select the type of change your pull request introduces:
- [ ] Bugfix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] This PR conforms to the process detailed in the [Contributing Guide](https://github.com/sandialabs/sceptre-docs/tree/master/.github/CONTRIBUTING.md).
- [x] I have included no proprietary/sensitive information in my code.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested my code.

## Additional Notes
Documentation for https://github.com/sandialabs/sceptre-bennu/pull/47 and https://github.com/sandialabs/sceptre-phenix-apps/pull/85. 